### PR TITLE
Move mockery to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "bugs": "https://github.com/martinheidegger/i18n-core/issues",
   "license": "ISC",
   "dependencies": {
-    "mockery": "^1.4.0",
     "mustache": "^0.8.2",
     "sprintf": "^0.1.4"
   },
@@ -24,6 +23,7 @@
   },
   "devDependencies": {
     "code": "^1.2.1",
-    "lab": "^5.1.0"
+    "lab": "^5.1.0",
+    "mockery": "^1.4.0"
   }
 }


### PR DESCRIPTION
`mockery` only appears to be used in the tests.
