### PR TITLE
Allow replacing multiple tokens in translations

### DIFF
--- a/lib/mustacheSimple.js
+++ b/lib/mustacheSimple.js
@@ -2,7 +2,7 @@
 var escapeHTML = require('escape-html')
 module.exports = {
   render: function mustacheSimple (value, namedValues) {
-    return value.replace(/{{(.*)}}/ig, function (match, param) {
+    return value.replace(/{{\s?({?[^}]*}?)\s?}}/ig, function (match, param) {
       var unescaped = /^{.*}$/.test(param)
       if (unescaped) {
         param = param.substring(1, param.length - 1)

--- a/test/mustacheSimple.js
+++ b/test/mustacheSimple.js
@@ -13,3 +13,9 @@ test('additional brace parameter replacement', function (t) {
   t.equals(render('hello {{{x}}}', {x: '<world>'}), 'hello <world>')
   t.end()
 })
+
+test('mutiple brace parameter replacement', function (t) {
+  t.equals(render('hello {{x}}, {{y}}', {x: 'world', y: 'nice day'}), 'hello world, nice day')
+  t.equals(render('hello {{x}}, {{y}} {{{z}}}', {x: 'world', y: 'nice day', z: 'huh?'}), 'hello world, nice day huh?')
+  t.end()
+})


### PR DESCRIPTION
As it stands the regex in `lib/mustacheSimple.js` is a bit too greedy so if you have a string like:

`my string to be translated has {{two}} {{parameters}}`

it'll match as `two}} {{parameters` instead of `two` and `parameters`.

This PR changes the regex to be less greedy & adds a test for the same.